### PR TITLE
Typecheck calls to arrow functions.

### DIFF
--- a/src/rules/function-args-length-must-match.js
+++ b/src/rules/function-args-length-must-match.js
@@ -1,5 +1,5 @@
 const {
-    getArgumentsForFunction,
+    getArgumentsForCalledFunction,
     getArgumentsForFunctionCall,
     getNameOfCalledFunction,
     storeProgram
@@ -10,7 +10,7 @@ module.exports = {
         return {
             CallExpression(node) {
                 const functionName = getNameOfCalledFunction(node, context);
-                const expectedArgs = getArgumentsForFunction(node, context);
+                const expectedArgs = getArgumentsForCalledFunction(node, context);
                 const args = getArgumentsForFunctionCall(node, context);
 
                 if ((!expectedArgs || !expectedArgs.length)

--- a/src/rules/function-args-types-must-match.js
+++ b/src/rules/function-args-types-must-match.js
@@ -1,5 +1,5 @@
 const {
-    getArgumentsForFunction,
+    getArgumentsForCalledFunction,
     getArgumentsForFunctionCall,
     getNameOfCalledFunction,
     storeProgram
@@ -14,7 +14,7 @@ module.exports = {
         return {
             CallExpression(node) {
                 const functionName = getNameOfCalledFunction(node, context);
-                const expectedArgs = getArgumentsForFunction(node, context);
+                const expectedArgs = getArgumentsForCalledFunction(node, context);
                 const callArgs = getArgumentsForFunctionCall(node, context);
 
                 if (!expectedArgs || !expectedArgs.length

--- a/src/rules/tests/function-args-types-must-match.test.js
+++ b/src/rules/tests/function-args-types-must-match.test.js
@@ -42,6 +42,34 @@ var a = foo(1, 'hello', true);
         });
     });
 
+    describe(`when the types of each argument matches the types of each argument in the arrow function signature`, function() {
+        const source = `
+
+/**
+ * @param {number} x
+ * @param {string|undefined} y
+ * @param {boolean} z
+ */
+const foo = (x, y, z) => {
+  return x + y + z;
+}
+
+var a = foo(1, 'hello', true);
+
+`;
+
+        let result = null;
+
+        beforeEach(async function() {
+            result = await doTest(source, lintOptions);
+        });
+
+        it(`should not show a message`, function() {
+            expect(result)
+                .toEqual([]);
+        });
+    });
+
     describe(`when the types of an argument does not match the type of an argument in the function signature`, function() {
         const source = `
 

--- a/src/rules/tests/function-args-types-must-match.test.js
+++ b/src/rules/tests/function-args-types-must-match.test.js
@@ -70,6 +70,34 @@ var a = foo(1, 'hello', true);
         });
     });
 
+    describe(`when an arrow function evaluates to a call with the correct signature`, function() {
+        const source = `
+
+/**
+ * @param {number} x
+ * @param {string|undefined} y
+ * @param {boolean} z
+ */
+const foo = (x, y, z) => {
+  return x + y + z;
+}
+
+const bar = () => foo(1, 'two', false);
+
+`;
+
+        let result = null;
+
+        beforeEach(async function() {
+            result = await doTest(source, lintOptions);
+        });
+
+        it(`should not show a message`, function() {
+            expect(result)
+                .toEqual([]);
+        });
+    });
+
     describe(`when the types of an argument does not match the type of an argument in the function signature`, function() {
         const source = `
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -317,6 +317,21 @@ function resolveTypeForNodeIdentifier(node, context) {
               return new Type(...(params[name] || []));
             }
         }
+        case `ArrowFunctionExpression`: {
+            const comment = getCommentForNode(definition, context);
+
+            if (!comment) {
+                return;
+            }
+
+            // The binding found is a parameter.
+            const params = extractParams(comment, context);
+            if (params[name] === undefined) {
+              return;
+            }
+
+            return new Type(...params[name]);
+        }
         case `ImportDefaultSpecifier`: {
             const externalSymbol = parent.imported.name;
             const fsPath = resolve(parent.source.value, context);

--- a/src/utils.js
+++ b/src/utils.js
@@ -298,7 +298,7 @@ function resolveTypeForNodeIdentifier(node, context) {
     const definition = idBinding.definition;
     const parent = definition.parent;
 
-    //    console.log(`getting type for scope definition:`, idBinding.definition.parent.type);
+    //    console.log(`getting type for scope definition:`, parent.type);
     switch (parent.type) {
         case `FunctionDeclaration`: {
             const comment = getCommentForNode(definition, context);
@@ -309,6 +309,7 @@ function resolveTypeForNodeIdentifier(node, context) {
 
             if (parent.id.name === name) {
               // The binding found is the function name.
+              // CHECK: shouldn't this be the type of the function, not the return type?
               return getReturnTypeFromComment(comment);
             } else {
               // The binding found is a function parameter.
@@ -317,23 +318,38 @@ function resolveTypeForNodeIdentifier(node, context) {
             }
         }
         case `ImportDefaultSpecifier`: {
-            const externalSymbol = idBinding.definition.parent.imported.name;
-            const fsPath = resolve(idBinding.definition.parent.parent.source.value, context);
+            const externalSymbol = parent.imported.name;
+            const fsPath = resolve(parent.source.value, context);
             const externalContext = getContextForFile(fsPath, context);
             const externalExportIdentifier = getDefaultExportIdentifierForSymbolName(externalSymbol, externalContext);
 
             return new Type(`${fsPath}:${externalSymbol}`);
         }
         case `ImportSpecifier`: {
-            const externalSymbol = idBinding.definition.parent.imported.name;
-            const fsPath = resolve(idBinding.definition.parent.parent.source.value, context);
+            const externalSymbol = parent.imported.name;
+            const fsPath = resolve(parent.parent.source.value, context);
             const externalContext = getContextForFile(fsPath, context);
             const externalExportIdentifier = getNamedExportIdentifierForSymbolName(externalSymbol, externalContext);
 
             return resolveTypeForNodeIdentifier(externalExportIdentifier, externalContext);
         }
         case `VariableDeclarator`: {
-            return resolveTypeForDeclaration(idBinding.definition.parent.id, context);
+            if (parent.init && parent.init.type === 'ArrowFunctionExpression') {
+              const comment = getCommentForNode(definition, context);
+              if (comment) {
+                // The binding may be an argument of the arrow expression.
+                const params = extractParams(comment, context);
+                if (params[name] !== undefined) {
+                  // The binding found may be a parameter.
+                  return new Type(...(params[name] || []));
+                } else if (name === parent.id.name) {
+                  // CHECK: This should be the type of the expression, not the type of a call to it.
+                  return getReturnTypeFromComment(comment);
+                }
+              }
+            }
+
+            return resolveTypeForDeclaration(parent.id, context);
         }
     }
 }
@@ -562,7 +578,56 @@ function getArgumentsForFunctionCall(node, context) {
  * @param {Context} context
  * @return {Type[]}
  */
-function getArgumentsForFunction(node, context) {
+function getArgumentsForFunctionDefinition(node, context) {
+    if (node === undefined) {
+      return;
+    }
+
+    // Arrow function definitions are in a slightly different place.
+    if (node.type === `VariableDeclarator`) {
+      if (node.init.type === `ArrowFunctionExpression`) {
+        node = node.init;
+      }
+    }
+
+    if (!node.params) {
+        return [];
+    }
+
+    const comment = getCommentForNode(node, context);
+
+    if (!comment) {
+        if (node.type !== `FunctionDeclaration` && node.type !== `ArrowFunctionExpression`) {
+          return;
+        }
+
+        return node.params.map(
+            (p) => new Type()
+        );
+    }
+
+    const params = extractParams(comment, context);
+
+    return node.params.map(function(p) {
+        switch (p.type) {
+            case `AssignmentPattern`:
+                return new Type(...params[p.left.name]);
+
+            case `FunctionDeclaration`:
+
+
+            default:
+                return new Type(...(params[p.name] || []));
+        }
+    });
+}
+
+/**
+ * @param {Node} node
+ * @param {Context} context
+ * @return {Type[]}
+ */
+function getArgumentsForCalledFunction(node, context) {
     if (!node || node.type !== `CallExpression`) {
         return;
     }
@@ -576,36 +641,9 @@ function getArgumentsForFunction(node, context) {
 
     if (!binding) {
         return;
-    } else if (!binding.definition.parent.params) {
-        return [];
     }
 
-    const comment = getCommentForNode(binding.definition.parent, context);
-
-    if (!comment) {
-        if (binding.definition.parent.type !== `FunctionDeclaration`) {
-            return;
-        }
-
-        return binding.definition.parent.params.map(
-            (p) => new Type()
-        );
-    }
-
-    const params = extractParams(comment, context);
-
-    return binding.definition.parent.params.map(function(p) {
-        switch (p.type) {
-            case `AssignmentPattern`:
-                return new Type(...params[p.left.name]);
-
-            case `FunctionDeclaration`:
-
-
-            default:
-                return new Type(...(params[p.name] || []));
-        }
-    });
+    return getArgumentsForFunctionDefinition(binding.definition.parent, context);
 }
 
 function getNameOfCalledFunction(node, context) {
@@ -637,7 +675,7 @@ function getContainingFunctionDeclaration(node, context) {
 }
 
 module.exports = {
-    getArgumentsForFunction,
+    getArgumentsForCalledFunction,
     getArgumentsForFunctionCall,
     getContainingFunctionDeclaration,
     getNameOfCalledFunction,

--- a/src/utils.js
+++ b/src/utils.js
@@ -428,13 +428,15 @@ function resolveTypeForDeclaration(node, context) {
 }
 
 function resolveTypeForFunctionDeclaration(node, context) {
-    if (!node || node.type !== `FunctionDeclaration`) {
+    if (!node) {
         return;
     }
 
-    const identifierComment = getCommentForNode(node, context);
+    if (node.type === `FunctionDeclaration` || node.type === 'ArrowFunctionExpression') {
+      const identifierComment = getCommentForNode(node, context);
 
-    return getReturnTypeFromComment(identifierComment, context);
+      return getReturnTypeFromComment(identifierComment, context);
+    }
 }
 
 function resolveTypeForBinaryExpression(node, context) {
@@ -682,7 +684,7 @@ function getContainingFunctionDeclaration(node, context) {
 
     let funcDecl = node;
 
-    while (funcDecl && funcDecl.type !== `FunctionDeclaration`) {
+    while (funcDecl && funcDecl.type !== `FunctionDeclaration` && funcDecl.type !== 'ArrowFunctionExpression') {
         funcDecl = funcDecl.parent;
     }
 


### PR DESCRIPTION
This gets the following to type check.

```
/**
 * @param {number} rgbInt
 * @returns {number[]}
 */
const toArrayFromRgbInt = (rgbInt) => [
  (rgbInt >> 16) & 0xff,
  (rgbInt >> 8) & 0xff,
  (rgbInt >> 0) & 0xff,
];

/**
 * @param {number} rgbInt
 * @returns {number[]}
 */
function toEntryFromRgbInt (rgbInt) {
  return toArrayFromRgbInt(rgbInt);
};
```