### PR TITLE
Do not crash when computing type of call to member expression.

### DIFF
--- a/src/rules/tests/assignment-types-must-match.test.js
+++ b/src/rules/tests/assignment-types-must-match.test.js
@@ -183,6 +183,25 @@ var x = foo();
         });
     });
 
+    describe(`when the value is a return value of a method`, function() {
+        const source = `
+/** @type {number} */
+var x = foo.bar();
+
+`;
+
+        let result = null;
+
+        beforeEach(async function() {
+            result = await doTest(source, lintOptions);
+        });
+
+        it(`should not show a message`, function() {
+            expect(result)
+                .toEqual([]);
+        });
+    });
+
     describe(`when the value is a return value of a function but not of the declared type`, function() {
         const source = `
 

--- a/src/rules/tests/function-args-types-must-match.test.js
+++ b/src/rules/tests/function-args-types-must-match.test.js
@@ -78,6 +78,25 @@ var a = foo(/*inline=*/ 'comment');
         });
     });
 
+    describe(`handles calls to built-in methods`, function() {
+        const source = `
+
+var a = foo.map(bar);
+
+`;
+
+        let result = null;
+
+        beforeEach(async function() {
+            result = await doTest(source, lintOptions);
+        });
+
+        it(`should not show a message`, function() {
+            expect(result)
+                .toEqual([]);
+        });
+    });
+
     describe(`when the types of each argument matches the types of each argument in the function signature`, function() {
         const source = `
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -542,6 +542,11 @@ function resolveTypeForArrowFunctionExpression(node, context) {
 }
 
 function resolveTypeForCallExpression(node, context) {
+    if (node.callee.type === 'MemberExpression') {
+        // How do we infer the type of a.b()?
+        // For now, produce no expectation rather than crash.
+        return;
+    }
     const binding = scan.getBinding(node.callee);
 
     if (!binding) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -707,6 +707,11 @@ function getArgumentsForFunctionCall(node, context) {
             case `Identifier`: {
                 const idBinding = scan.getBinding(a);
 
+                if (!idBinding.definition) {
+                  // We have no definition, so no expectations.
+                  return;
+                }
+
                 switch (idBinding.definition.parent.type) {
                     case `ArrowFunctionExpression`:
                     case `FunctionDeclaration`:


### PR DESCRIPTION
Unclear to me how we should compute the type, so have made it untyped for now.