### PR TITLE
Fix function type assignment and related.

### DIFF
--- a/src/Type.js
+++ b/src/Type.js
@@ -61,6 +61,7 @@ class Type extends Array {
     }
 
     toString() {
+        // Note: Discarding the qualifier leads to messages like 'string does not match string'.
         return this._objectLiteral
             ? `(object literal)`
             : this.map(

--- a/src/rules/function-return-type-must-match.js
+++ b/src/rules/function-return-type-must-match.js
@@ -1,6 +1,6 @@
 const {
     getContainingFunctionDeclaration,
-    resolveTypeForFunctionDeclaration,
+    resolveReturnTypeForFunctionDeclaration,
     resolveTypeForValue,
     storeProgram
 } = require('../utils');
@@ -17,7 +17,7 @@ module.exports = {
             },
             ReturnStatement(node) {
                 const functionDeclaration = getContainingFunctionDeclaration(node, context);
-                const expectedReturnType = resolveTypeForFunctionDeclaration(
+                const expectedReturnType = resolveReturnTypeForFunctionDeclaration(
                     functionDeclaration, context
                 );
 

--- a/src/rules/tests/assignment-types-must-match.test.js
+++ b/src/rules/tests/assignment-types-must-match.test.js
@@ -474,6 +474,59 @@ x = foo();
         });
     });
 
+    describe(`when the value is function of the declared type`, function() {
+        const source = `
+
+/** @type {function(number):string} */
+function foo(a) { return 's'; }
+
+/** @type {function(number):string} */
+var x;
+
+x = foo;
+
+`;
+
+        let result = null;
+
+        beforeEach(async function() {
+            result = await doTest(source, lintOptions);
+        });
+
+        it(`should not show a message`, function() {
+            expect(result)
+                .toEqual([])
+        });
+    });
+
+    describe(`when the value is function with suitable tags`, function() {
+        const source = `
+
+/**
+ * @params {number} a
+ * @return {stringXXX}
+ */
+function foo(a) { return 's'; }
+
+/** @type {function(number):stringXXX} */
+var x;
+
+x = foo;
+
+`;
+
+        let result = null;
+
+        beforeEach(async function() {
+            result = await doTest(source, lintOptions);
+        });
+
+        it(`should not show a message`, function() {
+            expect(result)
+                .toEqual([])
+        });
+    });
+
     describe(`when the value is an object literal of the declared type`, function() {
         const source = `
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,28 +54,28 @@ function parseJsdocImportString(importString, context) {
         : {};
 }
 
-function getTypeFromComment(comment) {
-    const typeTag = comment.tags.find(
-        (t) => t.tag === `type`
-    );
+function getTag(tagName, comment) {
+  return comment.tags.find(({ tag }) => tag === tagName);
+}
 
-    if (typeTag) {
+function getFunctionTypeTag(comment) {
+  return comment.tags.find((t) => t.tag === `type` && t.type.startsWith(`function(`));
+}
+
+function getTypeFromComment(comment) {
+    if (getTag(`type`, comment)) {
         return new Type(...typeTag.type.split(`|`));
     }
 }
 
 function getReturnTypeFromComment(comment, context) {
-    const returnTag = comment.tags.find(
-        (t) => t.tag === `return` || t.tag === `returns`
-    );
+    const returnTag = getTag(`return`, comment) || getTag(`returns`, comment);
 
-    if (returnTag) {
+    if (getTag(`return`, comment) || getTag(`returns`, comment)) {
         return new Type(...returnTag.type.split(`|`));
     }
 
-    const typeTag = comment.tags.find(
-        (t) => t.tag === `type` && t.type.startsWith(`function(`)
-    );
+    const typeTag = getFunctionTypeTag(comment);
 
     if (typeTag) {
         return getReturnTypeFromFunctionTypeString(typeTag.type, context);
@@ -226,9 +226,7 @@ function extractParams(comment, context) {
         }, {});
     }
 
-    const functionTypeTag = comment.tags.find(
-        (t) => t.tag === `type` && t.type.startsWith(`function(`)
-    );
+    const functionTypeTag = getFunctionTypeTag(comment);
 
     if (functionTypeTag) {
         const functionParams =
@@ -413,9 +411,7 @@ function resolveTypeForNodeIdentifier(node, context) {
                 return new Type(...params[name]);
             }
 
-            const typeTag = comment.tags.find(
-                (t) => t.tag === `type`
-            );
+            const typeTag = getTag(`type`, comment);
 
             if (!typeTag) {
                 return;
@@ -462,12 +458,36 @@ function resolveTypeFromComment(comment, context) {
         return;
     }
 
-    const typeTag = comment.tags.find(
-        (t) => t.tag === `type`
-    );
+    const typeTag = getTag(`type`, comment);
 
     if (typeTag) {
         return new Type(...typeTag.type.split(`|`));
+    }
+
+    // If we didn't find an @type, look for @param and @return,
+    // and see if we can construct a function type.
+
+    const functionTag = getTag(`function`, comment);
+    const callbackTag = getTag(`callback`, comment);
+
+    // Only consider contiguous indexes for now ...
+    const params = extractParams(comment, context);
+    const paramTypes = [];
+    for (let idx = 0; params[idx] !== undefined; idx++) {
+      types.push(params[idx]);
+    }
+    const returnType = getReturnTypeFromComment(comment, context);
+    if (!functionTag && !callbackTag && paramTypes.length === 0 && returnType === undefined) {
+      // We didn't find anything to construct a function type from.
+      // FIX: I guess finding an @function or @callback would justify producing
+      // function() as a type.
+      return;
+    }
+    if (returnType === undefined) {
+      // Is this how we represent a function with no expectation upon its return type?
+      return new Type(`function(${paramTypes.join(', ')})`);
+    } else {
+      return new Type(`function(${paramTypes.join(', ')}): ${returnType}`);
     }
 }
 
@@ -506,11 +526,13 @@ function resolveTypeForFunctionDeclaration(node, context) {
         return;
     }
 
-    const identifierComment = getCommentForNode(node, context);
+    const comment = getCommentForNode(node, context);
 
-    if (identifierComment) {
-        return getReturnTypeFromComment(identifierComment, context);
+    if (comment) {
+        return resolveTypeFromComment(comment, context);
     }
+
+    return new Type(`function`);
 }
 
 function resolveTypeForBinaryExpression(node, context) {
@@ -579,6 +601,8 @@ function resolveTypeForArrowFunctionExpression(node, context) {
     if (comment) {
         return resolveTypeFromComment(comment, context);
     }
+
+    return new Type(`function`);
 }
 
 function resolveTypeForCallExpression(node, context) {
@@ -644,7 +668,7 @@ function resolveTypeForValue(node, context) {
             return resolveTypeForConditionalExpression(node, context);
 
         case `FunctionDeclaration`:
-            return new Type(`function`);
+            return resolveTypeForFunctionDeclaration(node, context);
 
         case `Identifier`:
             return resolveTypeForNodeIdentifier(node, context);
@@ -798,9 +822,7 @@ function getArgumentsForFunctionDefinition(node, context) {
         });
     }
 
-    const typeTag = comment.tags.find(
-        (t) => t.tag === `type`
-    );
+    const typeTag = getTag(`type`, comment);
 
     return typeTag
         ? getParamTypesFromFunctionTypeString(typeTag.type, context)

--- a/src/utils.js
+++ b/src/utils.js
@@ -485,9 +485,9 @@ function resolveTypeFromComment(comment, context) {
     }
     if (returnType === undefined) {
       // Is this how we represent a function with no expectation upon its return type?
-      return new Type(`function(${paramTypes.join(', ')})`);
+      return new Type(`function(${paramTypes.join(',')})`);
     } else {
-      return new Type(`function(${paramTypes.join(', ')}): ${returnType}`);
+      return new Type(`function(${paramTypes.join(',')}):${returnType}`);
     }
 }
 


### PR DESCRIPTION
Fixes a number of places which confuse the function type with the function return types.

Normalizes /** @param ... @return ... */ declarations with /** @type {function()} */ declarations.

Refactor tag accessors.