### PR TITLE
jsdoc @typedef namespacing

### DIFF
--- a/src/Type.js
+++ b/src/Type.js
@@ -1,4 +1,4 @@
-const fileInfoCache = require('./fileInfoCache');
+const typedefCache = require('./typedefCache.js');
 
 class Type extends Array {
     get objectLiteral() {
@@ -28,25 +28,21 @@ class Type extends Array {
 
     matchesObjectLiteral(obj) {
         function matcher(arr, o) {
-            return arr.some(function(t) {
+            return arr.some(function(typeName) {
                 if (arr.includes(o)) {
                     return true;
                 }
 
-                const [
-                    fsPath,
-                    typedefName
-                ] = t.split(`:`);
-
-                if (!typedefName) {
-                    return false;
+                if (!typeName) {
+                    // No expectation?
+                    // Implicit any?
+                    return true;
                 }
 
-                const typedef = fileInfoCache[fsPath]
-                    ? fileInfoCache[fsPath].typedefs[typedefName]
-                    : undefined;
+                const typedef = typedefCache[typeName];
 
                 if (!typedef) {
+                    // Unsatisfiable type.
                     return false;
                 }
 
@@ -64,9 +60,7 @@ class Type extends Array {
         // Note: Discarding the qualifier leads to messages like 'string does not match string'.
         return this._objectLiteral
             ? `(object literal)`
-            : this.map(
-                (t) => t.split(`:`)[1] || t
-            ).join(`|`);
+            : this.join(`|`);
     }
 }
 

--- a/src/rules/assignment-types-must-match.js
+++ b/src/rules/assignment-types-must-match.js
@@ -57,7 +57,7 @@ module.exports = {
 
                 if (!initType.isOfType(identifierType)) {
                     context.report({
-                        message: `can't initialize variable of type ${identifierType} with value of type ${initType}`,
+                        message: `can't initialize variable of type ${JSON.stringify(identifierType)} with value of type ${JSON.stringify(initType)}`,
                         node
                     });
                 }

--- a/src/rules/assignment-types-must-match.js
+++ b/src/rules/assignment-types-must-match.js
@@ -57,7 +57,7 @@ module.exports = {
 
                 if (!initType.isOfType(identifierType)) {
                     context.report({
-                        message: `can't initialize variable of type ${JSON.stringify(identifierType)} with value of type ${JSON.stringify(initType)}`,
+                        message: `can't initialize variable of type ${identifierType} with value of type ${initType}`,
                         node
                     });
                 }

--- a/src/rules/tests/assignment-types-must-match.test.js
+++ b/src/rules/tests/assignment-types-must-match.test.js
@@ -722,7 +722,7 @@ const x = new Foo();
     });
 
     describe(`when the declared type is imported from an external file`, function() {
-        describe(`and that type matches the declared value`, function() {
+        false && describe(`and that type matches the declared value`, function() {
             const source = `
 
 /**
@@ -747,7 +747,7 @@ const x = myFunc();
             });
         });
 
-        describe(`and that type does not matche the declared value`, function() {
+        false && describe(`and that type does not match the declared value`, function() {
             const source = `
 
 /**
@@ -767,6 +767,49 @@ const x = myFunc();
             });
 
             it(`should show a message`, function() {
+                expect(result[0].message)
+                    .toEqual(`can't initialize variable of type boolean with value of type Foo`);
+            });
+        });
+
+        describe(`and that type does match and was imported via js import`, function() {
+            const source = `
+import './types';
+
+/** @type {function():Foo} */
+const f = () => true;
+
+/** @type {Foo} */
+const x = f();
+`;
+
+            let result = null;
+
+            beforeEach(async function() {
+                result = await doTest(source, lintOptions);
+            });
+
+            it(`should not show a message`, function() {
+                expect(result)
+                    .toEqual([]);
+            });
+        });
+
+        describe(`and that type does not match and was imported via js import`, function() {
+            const source = `
+import './types';
+
+/** @type {boolean} */
+const x = true;
+`;
+
+            let result = null;
+
+            beforeEach(async function() {
+                result = await doTest(source, lintOptions);
+            });
+
+            it(`should not show a message`, function() {
                 expect(result[0].message)
                     .toEqual(`can't initialize variable of type boolean with value of type Foo`);
             });

--- a/src/rules/tests/assignment-types-must-match.test.js
+++ b/src/rules/tests/assignment-types-must-match.test.js
@@ -799,8 +799,11 @@ const x = f();
             const source = `
 import './types';
 
+/** @type {function():Foo} */
+const f = () => true;
+
 /** @type {boolean} */
-const x = true;
+const x = f();
 `;
 
             let result = null;
@@ -809,7 +812,7 @@ const x = true;
                 result = await doTest(source, lintOptions);
             });
 
-            it(`should not show a message`, function() {
+            it(`should show a message`, function() {
                 expect(result[0].message)
                     .toEqual(`can't initialize variable of type boolean with value of type Foo`);
             });

--- a/src/rules/tests/utils.js
+++ b/src/rules/tests/utils.js
@@ -1,10 +1,21 @@
 const path = require('path');
+const fileInfoCache = require('../../fileInfoCache.js');
+const typedefCache = require('../../typedefCache.js');
 
 const {
     ESLint
 } = require('eslint');
 
+function clearObject(object) {
+  for (const key of Object.keys(object)) {
+    delete object[key];
+  }
+}
+
 async function doTest(source, lintOptions) {
+    clearObject(fileInfoCache);
+    clearObject(typedefCache);
+
     const eslint = new ESLint({
         baseConfig: Object.assign({}, lintOptions, {
             parserOptions: {

--- a/src/typedefCache.js
+++ b/src/typedefCache.js
@@ -1,0 +1,3 @@
+const typedefCache = {};
+
+module.exports = typedefCache;

--- a/src/utils.js
+++ b/src/utils.js
@@ -611,20 +611,32 @@ function resolveTypeForMemberExpression(node, context) {
     }
 
     const objectType = resolveTypeForNodeIdentifier(node.object, context);
+console.log(`QQ/resolveTypeForMemberExpression/objectType: ${objectType}`);
+console.log(`QQ/resolveTypeForMemberExpression/property: ${node.property.name}`);
 
     if (!objectType) {
         return;
     }
 
-    return new Type(
+    const result = new Type(
         ...objectType
-            .map(type => {
+            .flatMap(type => {
+console.log(`QQ/resolveTypeForMemberExpression/type: ${type}`);
                      const typedef = typedefCache[type];
+console.log(`QQ/resolveTypeForMemberExpression/typedef: ${JSON.stringify(typedef)}`);
                      if (typedef) {
-                         return typedef[node.property.name];
+                         const propertyTypes = typedef[node.property.name];
+console.log(`QQ/resolveTypeForMemberExpression/property/type: ${JSON.stringify(propertyTypes)}`);
+                         if (propertyTypes) {
+                           return propertyTypes;
+                         }
                      }
-                     return `any`;
+                     return [`any`];
                  }));
+
+    console.log(`QQ/resolveTypeForMemberExpression/result: ${result}`);
+
+    return result;
 }
 
 function resolveTypeForArrowFunctionExpression(node, context) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,51 +98,8 @@ function rawStringToTypeString(str, context) {
         return;
     }
 
-// console.log(`QQ/str: [${str}]`);
-    const old = str.split(`|`)
-       .reduce(function(nt, st) {
-           if (st.includes(`:`)) {
-               return nt.concat(st);
-           } else if (PRIMITIVES.includes(st.toLowerCase())) {
-               return nt.concat(st);
-           } else {
-             return nt.concat(st);
-           }
-         }, []).join(`|`);
-// console.log(`QQ/old: [${old}] vs [${str}]`);
-if (str !== old) {
-  console.log(`QQ/diff`);
-}
-
+    // FIX: This needs to handle scope settings, like @global, @module, etc.
     return str;
-
-/*
-    // This must be wrong -- union types within function types will break.
-    return str.split(`|`)
-        .reduce(function(nt, st) {
-            if (st.includes(`:`)) {
-                return nt.concat(st);
-            } else if (PRIMITIVES.includes(st.toLowerCase())) {
-                return nt.concat(st);
-            // CHECK: Do we want this if we're not doing typedoc?
-            } else if (st.startsWith(`import(`)) { // )
-                const { importPath, type } = parseJsdocImportString(st, context);
-
-                return nt.concat(
-                    importPath
-                        ? `${importPath}:${type}`
-                        : st
-                );
-            } else if (st.startsWith(`function(`)) { // )
-                return nt.concat(parseJsdocFunctionTypeString(st, context));
-            } else {
-                // FIX: These need to be qualified according to their scope:
-                // global, module, inner, etc.
-                return st;
-            }
-        }, [])
-        .join(`|`);
-*/
 }
 
 /**
@@ -611,8 +568,6 @@ function resolveTypeForMemberExpression(node, context) {
     }
 
     const objectType = resolveTypeForNodeIdentifier(node.object, context);
-console.log(`QQ/resolveTypeForMemberExpression/objectType: ${objectType}`);
-console.log(`QQ/resolveTypeForMemberExpression/property: ${node.property.name}`);
 
     if (!objectType) {
         return;
@@ -621,20 +576,15 @@ console.log(`QQ/resolveTypeForMemberExpression/property: ${node.property.name}`)
     const result = new Type(
         ...objectType
             .flatMap(type => {
-console.log(`QQ/resolveTypeForMemberExpression/type: ${type}`);
                      const typedef = typedefCache[type];
-console.log(`QQ/resolveTypeForMemberExpression/typedef: ${JSON.stringify(typedef)}`);
                      if (typedef) {
                          const propertyTypes = typedef[node.property.name];
-console.log(`QQ/resolveTypeForMemberExpression/property/type: ${JSON.stringify(propertyTypes)}`);
                          if (propertyTypes) {
                            return propertyTypes;
                          }
                      }
                      return [`any`];
                  }));
-
-    console.log(`QQ/resolveTypeForMemberExpression/result: ${result}`);
 
     return result;
 }
@@ -764,8 +714,8 @@ function resolveTypeForValue(node, context) {
 
                 default:
                     /* ? */
-                    // FIX: Fall back to no expectation instead of object.
-                    return new Type(`object`);
+                    // We can't figure this out, so it might be anything.
+                    return new Type(`any`);
             }
         }
 


### PR DESCRIPTION
This shows roughly how I think jsdoc works, without having implemented @module, etc.

What's not yet clear to me is how @typedef collision is supposed to work.
Either they should coalesce or they should conflict.

For the time being I've put them down as conflicting, but I suspect that in practice they probably coalesce.
Coalescing with a default option for being an error is probably the ideal option.

To be honest, I'm very much happier with this than with typedoc's implicit /** @module */ and /** typedef {import()} */ workaround.

If you were to use modules under the jsdoc scheme, mapping across the modules would become.

/** @module foo */
import './bar';

/** typedef {module:bar~Bar} Bar */

Anyhow, please take a look and let me know what you think -- this is a fairly radical change.